### PR TITLE
Add a VERSION argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get -y update                                            && \
       python-zmq                                                    \
       xvfb
 WORKDIR /usr/local/src
-ARG VERSION=master
+ARG VERSION=stable
 RUN git clone -b $VERSION https://github.com/CellProfiler/CellProfiler.git
 WORKDIR /usr/local/src/CellProfiler
 RUN pip install                                                     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ RUN apt-get -y update                                            && \
       python-zmq                                                    \
       xvfb
 WORKDIR /usr/local/src
-RUN git clone https://github.com/CellProfiler/CellProfiler.git
+ARG VERSION=master
+RUN git clone -b $VERSION https://github.com/CellProfiler/CellProfiler.git
 WORKDIR /usr/local/src/CellProfiler
 RUN pip install                                                     \
   --editable                                                        \


### PR DESCRIPTION
Previously, master of CellProfiler/CellProfiler was always built,
since the Dockerfile is not hosted in the main repo. Since only a
change to this repository triggers a rebuild, the version available
on hub.docker.com is disconnected from the main release cycle. By
adding a build argument which version of CellProfiler is built can
be controlled locally:

```
$ docker build -t cp-220 --build-arg VERSION=2.2.0 .
$ docker run -ti --rm cp-220 --version
CellProfiler 2.2.0
Git ac0529e
Version 20160503183100
Built 2016-05-03T18:31:00
```

This is a first step towarding having trusted tags on Docker Hub.
Additionally, on each CellProfiler release, a new commit will need
to be created and tagged which sets VERSION to the correct value.
If the Docker Hub build is configured properly, a new image will be
built when that tag is pushed to GitHub.